### PR TITLE
Automatically filter out IPv4/IPv6 CIDRs if the WireGuard profile cannot route them

### DIFF
--- a/cmd/ansible-wg-sync/main.go
+++ b/cmd/ansible-wg-sync/main.go
@@ -37,7 +37,7 @@ func main() {
 	}
 	withDebug = cfg.Debug
 	allowedIPs := getAllowedIPs(cfg)
-	logger.Println("loaded", len(allowedIPs), "allowed IPs")
+	logger.Println("discovered", len(allowedIPs), "allowed IPs")
 	if len(allowedIPs) == 0 {
 		logger.Println("WARNING: no allowed IPs found")
 		return


### PR DESCRIPTION
This is a follow up to IPv6 support landing in https://github.com/etkecc/ansible-wg-sync/pull/1

It turns out that for WireGuard VPNs that don't assign IPv6 addresses, one doesn't wish to add routes that handle IPv6 CIDRs, because they cannot be routed correctly through the IPv6-incapable interface.

It's better to avoid adding such routes, so that other interfaces can handle them.

The same applies to IPv4. For a WireGuard profile that's capable of IPv6 only, it makes no sense trying to route IPv4 requests over it.